### PR TITLE
Allow for passing the page node data back to the repositories through a object

### DIFF
--- a/MVC/MVC.Libraries/Libraries/Extensions/TreeNodeExtensions.cs
+++ b/MVC/MVC.Libraries/Libraries/Extensions/TreeNodeExtensions.cs
@@ -85,7 +85,29 @@ namespace Generic.Libraries.Extensions
             return pageIdentity;
         }
 
-
+        /// <summary>
+        /// Retrieves the typed object from the generic PageIdentity
+        /// </summary>
+        /// <typeparam name="TPage"></typeparam>
+        /// <param name="pageIdentity"></param>
+        /// <returns></returns>
+        public static PageIdentity<TPage> AsTyped<TPage>(this PageIdentity pageIdentity) {
+            // Explicitly casting in order to throw error if incorrect type
+            return new PageIdentity<TPage>()
+            {
+                Name = pageIdentity.Name,
+                Alias = pageIdentity.Alias,
+                NodeID = pageIdentity.NodeID,
+                NodeGUID = pageIdentity.NodeGUID,
+                DocumentID = pageIdentity.DocumentID,
+                DocumentGUID = pageIdentity.DocumentGUID,
+                Path = pageIdentity.Path,
+                RelativeUrl = pageIdentity.RelativeUrl,
+                AbsoluteUrl = pageIdentity.AbsoluteUrl,
+                NodeLevel = pageIdentity.NodeLevel,
+                Data = (TPage)pageIdentity.Data
+            };
+        }
 
         /// <summary>
         /// DocumentURLProvider.GetPresentationUrl() does various uncached database calls, this caches that to minimize calls for absolute url

--- a/MVC/MVC.Models/Models/PageIdentity.cs
+++ b/MVC/MVC.Models/Models/PageIdentity.cs
@@ -2,7 +2,7 @@
 
 namespace Generic.Models
 {
-    public record PageIdentity
+    public record PageIdentityBase
     {
         /// <summary>
         /// The Name of the page
@@ -55,11 +55,37 @@ namespace Generic.Models
         public int NodeLevel { get; init; }
     }
 
-    public record PageIdentity<T> : PageIdentity
+    public record PageIdentity : PageIdentityBase
+    {
+        /// <summary>
+        /// Generic page data
+        /// </summary>
+        public object Data { get; set; }
+    }
+
+    public record PageIdentity<T> : PageIdentityBase
     {
         /// <summary>
         /// Typed page data
         /// </summary>
         public T Data { get; set; }
+
+        public static implicit operator PageIdentity(PageIdentity<T> d)
+        {
+            return new PageIdentity()
+            {
+                Name = d.Name,
+                Alias = d.Alias,
+                NodeID = d.NodeID,
+                NodeGUID = d.NodeGUID,
+                DocumentID = d.DocumentID,
+                DocumentGUID = d.DocumentGUID,
+                Path = d.Path,
+                RelativeUrl = d.RelativeUrl,
+                AbsoluteUrl = d.AbsoluteUrl,
+                NodeLevel = d.NodeLevel,
+                Data = d.Data
+            };
+        }
     }
 }


### PR DESCRIPTION
Allows for passing a page template's node data to the backend and then casting it back to the correct type. 

Non breaking change.